### PR TITLE
N+1 Query Optimization

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -37,23 +37,35 @@ class HomeController < ApplicationController
     @invitePage = [ @invitePage, (@invitesLength / ITEMS_PER_PAGE).floor ].min
 
     # General Posts (All)
-    @posts = Post.order(created_at: :desc)
+    @posts = Post.includes(:comments).order(created_at: :desc)
                  .offset(@postPage * ITEMS_PER_PAGE)
                  .limit(ITEMS_PER_PAGE)
 
     # General Events (All)
-    @events = Event.order(created_at: :desc)
+    @events = Event.left_joins(:rsvps)
+    .select("events.*, 
+      COUNT(CASE WHEN rsvps.status = 'yes' THEN 1 END) AS yes_count, 
+      COUNT(CASE WHEN rsvps.status = 'no' THEN 1 END) AS no_count")
+    .group('events.id').order(created_at: :desc)
                    .offset(@eventPage * ITEMS_PER_PAGE)
                    .limit(ITEMS_PER_PAGE)
 
     # Future Events
-    @futureEvents = Event.where("time > ?", Time.now)
+    @futureEvents = Event.where("time > ?", Time.now).left_joins(:rsvps)
+    .select("events.*, 
+      COUNT(CASE WHEN rsvps.status = 'yes' THEN 1 END) AS yes_count, 
+      COUNT(CASE WHEN rsvps.status = 'no' THEN 1 END) AS no_count")
+    .group('events.id')
                          .order(created_at: :desc)
                          .offset(@futureEventPage * ITEMS_PER_PAGE)
                          .limit(ITEMS_PER_PAGE)
 
     # Past Events
-    @pastEvents = Event.where("time < ?", Time.now)
+    @pastEvents = Event.where("time < ?", Time.now).left_joins(:rsvps)
+    .select("events.*, 
+      COUNT(CASE WHEN rsvps.status = 'yes' THEN 1 END) AS yes_count, 
+      COUNT(CASE WHEN rsvps.status = 'no' THEN 1 END) AS no_count")
+    .group('events.id')
                        .order(created_at: :desc)
                        .offset(@pastEventPage * ITEMS_PER_PAGE)
                        .limit(ITEMS_PER_PAGE)

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -20,6 +20,7 @@ class ProfileController < ApplicationController
       @postPage = 0 if @postPage < 0
       @postPage = [ @postPage, (@postsLength / ITEMS_PER_PAGE).floor ].min
       @posts = Post.where(username: session[:current_user_id])
+                   .includes(:comments)
                    .order(created_at: :desc)
                    .offset(@postPage * ITEMS_PER_PAGE)
                    .limit(ITEMS_PER_PAGE)
@@ -29,6 +30,11 @@ class ProfileController < ApplicationController
       @postedEventPage = 0 if @postedEventPage < 0
       @postedEventPage = [ @postedEventPage, (@postedEventsLength / ITEMS_PER_PAGE).floor ].min
       @postedEvents = Event.where(username: session[:current_user_id])
+      .left_joins(:rsvps)
+      .select("events.*, 
+        COUNT(CASE WHEN rsvps.status = 'yes' THEN 1 END) AS yes_count, 
+        COUNT(CASE WHEN rsvps.status = 'no' THEN 1 END) AS no_count")
+      .group('events.id')
                    .order(created_at: :desc)
                    .offset(@postedEventPage * ITEMS_PER_PAGE)
                    .limit(ITEMS_PER_PAGE)

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -12,7 +12,7 @@
       <li class="list-group-item">
         <%= link_to post.title, post, class: 'text-decoration-none' %>
         <div>
-          <%= post.created_at.strftime("%A, %b %d, %Y at %I:%M %p") %> | <%= post.body %> |(<% post.comments.length %>) Comments
+          <%= post.created_at.strftime("%A, %b %d, %Y at %I:%M %p") %> | <%= post.body %> | Comments: (<%= post.comments.length %>)
         </div>
       </li>
     <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -12,7 +12,7 @@
       <li class="list-group-item">
         <%= link_to post.title, post, class: 'text-decoration-none' %>
         <div>
-          <%= post.created_at.strftime("%A, %b %d, %Y at %I:%M %p") %> | <%= post.body %>
+          <%= post.created_at.strftime("%A, %b %d, %Y at %I:%M %p") %> | <%= post.body %> |(<% post.comments.length %>) Comments
         </div>
       </li>
     <% end %>
@@ -37,8 +37,8 @@
         <%= link_to event.title, event, class: 'text-decoration-none' %>
         <div>
           Time: <%= event.time %>, Location: <%= event.location %>;
-          <b>Yes</b> RSVPs: <%= event.rsvps.where(status: 'yes').count %>,
-          <b>No</b> RSVPs: <%= event.rsvps.where(status: 'no').count %>
+          <b>Yes</b> RSVPs: <%= event.yes_count %>,
+          <b>No</b> RSVPs: <%= event.no_count %>
         </div>
       </li>
     <% end %>
@@ -59,8 +59,8 @@
         <%= link_to event.title, event, class: 'text-decoration-none' %>
         <div>
           Time: <%= DateTime.parse(event.time).strftime("%A, %b %d, %Y at %I:%M %p") %>, Location: <%= event.location %>;
-          <b>Yes</b> RSVPs: <%= event.rsvps.where(status: 'yes').count %> |
-          <b>No</b> RSVPs: <%= event.rsvps.where(status: 'no').count %>
+          <b>Yes</b> RSVPs: <%= event.yes_count %> |
+          <b>No</b> RSVPs: <%= event.no_count %>
         </div>
       </li>
     <% end %>
@@ -81,8 +81,8 @@
         <%= link_to event.title, event, class: 'text-decoration-none' %>
         <div>
           Time: <%= DateTime.parse(event.time).strftime("%A, %b %d, %Y at %I:%M %p") %>, Location: <%= event.location %>;
-          <b>Yes</b> RSVPs: <%= event.rsvps.where(status: 'yes').count %>,
-          <b>No</b> RSVPs: <%= event.rsvps.where(status: 'no').count %>
+          <b>Yes</b> RSVPs: <%= event.yes_count %>,
+          <b>No</b> RSVPs: <%= event.no_count %>
         </div>
       </li>
     <% end %>

--- a/app/views/profile/index.html.erb
+++ b/app/views/profile/index.html.erb
@@ -79,8 +79,8 @@
           <%= link_to event.title, event, class: 'text-decoration-none' %>
           <div>
             Time: <%= event.time %>, Location: <%= event.location %>;
-            <b>Yes</b> RSVPs: <%= event.rsvps.where(status: 'yes').count %>,
-            <b>No</b> RSVPs: <%= event.rsvps.where(status: 'no').count %>
+            <b>Yes</b> RSVPs: <%= event.yes_count %>,
+            <b>No</b> RSVPs: <%= event.no_count %>
           </div>
         </li>
       <% end %>


### PR DESCRIPTION
closes https://github.com/scalableinternetservices/schrodingers-full-stack/issues/60

This pr optimizes the queries needed to load all posts and events in the home and profile pages. The N+1 query problem is when a query is triggered for every single associated model (e.g. loading the counts of rsvp for events, counts of comments for posts).

<img width="623" alt="Screenshot 2024-12-09 at 9 44 44 PM" src="https://github.com/user-attachments/assets/d26770ff-3bf8-4ab8-88f9-11fb37c145f8">
<img width="623" alt="Screenshot 2024-12-09 at 9 46 10 PM" src="https://github.com/user-attachments/assets/2d55ddd0-c59a-4084-85a0-088252e3e410">
<img width="1029" alt="Screenshot 2024-12-09 at 9 47 09 PM" src="https://github.com/user-attachments/assets/2dc46ce7-0186-4bd1-90b3-7d0136ced91b">
